### PR TITLE
hacker news 被墙，添加规则

### DIFF
--- a/factory/manual_gfwlist.txt
+++ b/factory/manual_gfwlist.txt
@@ -40,3 +40,6 @@ phobos
 
 # 修复 google voice #112
 74.125.23.127
+
+# hacker news web site
+news.ycombinator.com


### PR DESCRIPTION
技术新闻聚合站 hacker news 访问存在问题。[相关新闻](https://www.solidot.org/story?sid=61590)

网址：news.ycombinator.com

gfwlist repo 中的 [issue](https://github.com/gfwlist/gfwlist/issues/1662) 目前还没有被合并。

